### PR TITLE
chore(dist): ignore the dist files but still commit them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 .DS_Store
+dist/

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
 	"main": "src/main.js",
 	"scripts": {
 		"start": "npm run watch:all",
+		"watch:all": "find ./src/ ./test/ -type f | entr npm run all",
+		"watch:test": "find ./src/ ./test/ -type f | entr npm test",
+		"all": "npm run format && npm run lint && npm run test && npm run build && npm run build:add",
 		"test": "jest",
-		"all": "npm run format && npm run lint && npm run test && npm run build",
-		"build": "ncc build src/main.js --source-map --minify --out dist/ --license LICENSE && git add ./dist/* --force",
+		"build": "ncc build src/main.js --source-map --minify --out dist/ --license LICENSE",
+		"build:add": "git add ./dist/* --force",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
-		"lint": "eslint .",
-		"watch:all": "find ./src/ ./test/ -type f | entr npm run all",
-		"watch:test": "find ./src/ ./test/ -type f | entr npm test"
+		"lint": "eslint ."
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"start": "npm run watch:all",
 		"test": "jest",
 		"all": "npm run format && npm run lint && npm run test && npm run build",
-		"build": "ncc build src/main.js --source-map --minify --out dist/ --license LICENSE",
+		"build": "ncc build src/main.js --source-map --minify --out dist/ --license LICENSE && git add ./dist/* --force",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"lint": "eslint .",

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const { GitHub } = require("./github");
 const { prettify: p } = require("./utils");
 
 function main() {
+	console.log("TEST");
 	try {
 		const configPath = core.getInput("config-path", { required: true });
 		let token = core.getInput("token", { required: true });

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ const { GitHub } = require("./github");
 const { prettify: p } = require("./utils");
 
 function main() {
-	console.log("TEST");
 	try {
 		const configPath = core.getInput("config-path", { required: true });
 		let token = core.getInput("token", { required: true });


### PR DESCRIPTION
Frankly, there surely should be a better way than committing your dist/ in the repo. I have not found one yet, but I am also not really sure it's possible. Here's an alternative: add them in the gitignore so all the cli tools will ignore them (rg, fzf, telescope, etc) but for commit them each time a build is made. So it's impossible to _not_ have them present in a commit whenever there's a change and `npm run build` is run.