### PR TITLE
fix(github): get Pull with correct head format

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -135,7 +135,11 @@ class GitHub {
 			.list({
 				owner: owner,
 				repo: repo,
-				head: head,
+				head: `${owner}:${head}`,
+
+				// We'll use only the first item anyway, and we'll warn if more
+				// than one PR exist for such a head.
+				per_page: 2,
 			})
 			.then(({ data }) => {
 				// There really should not be more than one Pull matching this

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -300,18 +300,21 @@ describe("GitHub", () => {
 	});
 
 	describe("getOrCreatePullRequest", () => {
+		const expectedcalls = () => {
+			expect(g.octokit.rest.pulls.list).toHaveBeenCalledWith({
+				owner: repo.owner,
+				repo: repo.repo,
+				head: `${repo.owner}:${branch}`,
+				per_page: 2,
+			});
+		};
 		it("gets an existing pull request", async () => {
 			g.octokit.rest.pulls.list.mockResolvedValue({ data: ["pull"] });
 
 			await expect(
 				g.getOrCreatePullRequest(repo, branch, "base", "title", "body"),
 			).resolves.toEqual("pull");
-
-			expect(g.octokit.rest.pulls.list).toHaveBeenCalledWith({
-				owner: repo.owner,
-				repo: repo.repo,
-				head: branch,
-			});
+			expectedcalls();
 		});
 
 		it("gets an existing pull request and warns for duplicates", async () => {
@@ -324,11 +327,7 @@ describe("GitHub", () => {
 			expect(core.warning).toHaveBeenCalledWith(
 				`found 2 PRs for ${prettyBranch}`,
 			);
-			expect(g.octokit.rest.pulls.list).toHaveBeenCalledWith({
-				owner: repo.owner,
-				repo: repo.repo,
-				head: branch,
-			});
+			expectedcalls();
 		});
 
 		it("creates a new pull request", async () => {
@@ -339,11 +338,7 @@ describe("GitHub", () => {
 				g.getOrCreatePullRequest(repo, branch, "base", "title", "body"),
 			).resolves.toEqual("pull");
 
-			expect(g.octokit.rest.pulls.list).toHaveBeenCalledWith({
-				owner: repo.owner,
-				repo: repo.repo,
-				head: branch,
-			});
+			expectedcalls();
 			expect(g.octokit.rest.pulls.create).toHaveBeenCalledWith({
 				owner: repo.owner,
 				repo: repo.repo,


### PR DESCRIPTION
The format isn't only the branch name, since they can come from forks, but the owner + branch name.