### PR TITLE
refactor(all): use ESM

### DIFF
--- a/__fixtures__/@actions/core.js
+++ b/__fixtures__/@actions/core.js
@@ -1,0 +1,10 @@
+import { jest } from "@jest/globals";
+
+export const debug = jest.fn();
+export const info = jest.fn();
+export const notice = jest.fn();
+export const error = jest.fn();
+export const warning = jest.fn();
+export const setFailed = jest.fn();
+export const getInput = jest.fn();
+export const setOutput = jest.fn();

--- a/__fixtures__/@actions/github.js
+++ b/__fixtures__/@actions/github.js
@@ -1,0 +1,8 @@
+import { jest } from "@jest/globals";
+
+export const github = {
+	context: {
+		repo: { owner: "owner", repo: "repo" },
+	},
+	getOctokit: jest.fn(),
+};

--- a/__fixtures__/js-yaml.js
+++ b/__fixtures__/js-yaml.js
@@ -1,0 +1,5 @@
+import { jest } from "@jest/globals";
+
+export default {
+	load: jest.fn(),
+};

--- a/__fixtures__/node/crypto.js
+++ b/__fixtures__/node/crypto.js
@@ -1,0 +1,5 @@
+import { jest } from "@jest/globals";
+
+export const crypto = {
+	hash: jest.fn(),
+};

--- a/__fixtures__/node/fs/promises.js
+++ b/__fixtures__/node/fs/promises.js
@@ -1,0 +1,5 @@
+import { jest } from "@jest/globals";
+
+export default {
+	readFile: jest.fn(),
+};

--- a/__fixtures__/src/link.js
+++ b/__fixtures__/src/link.js
@@ -1,0 +1,11 @@
+import { jest } from "@jest/globals";
+
+const parse = jest.fn();
+class Link {
+	static parse = parse;
+	constructor() {
+		return { parse: parse };
+	}
+}
+
+export { Link };

--- a/__tests__/config.js
+++ b/__tests__/config.js
@@ -1,20 +1,23 @@
-// required by File, which is required by Link
-jest.mock("@actions/github", () => ({ context: { repo: "repo" } }));
+import { jest } from "@jest/globals";
 
-// Prevents core logging
-jest.mock("@actions/core");
+import { github } from "../__fixtures__/@actions/github.js";
+jest.unstable_mockModule("@actions/github", () => github);
 
-const fs = require("node:fs/promises");
-jest.mock("node:fs/promises");
+import * as core from "../__fixtures__/@actions/core.js";
+jest.unstable_mockModule("@actions/core", () => core);
 
-const yaml = require("js-yaml");
-jest.mock("js-yaml");
+import fs from "../__fixtures__/node/fs/promises.js";
+jest.unstable_mockModule("node:fs/promises", () => fs);
 
-const { dedent } = require("../src/format");
-const { Config, ParseError } = require("../src/config");
+import yaml from "../__fixtures__/js-yaml.js";
+jest.unstable_mockModule("js-yaml", () => yaml);
 
-const { Link } = require("../src/link");
-jest.mock("../src/link");
+import { Link } from "../__fixtures__/src/link.js";
+jest.unstable_mockModule("../src/link.js", () => ({ Link: Link }));
+
+const { Config, ParseError } = await import("../src/config.js");
+
+import { dedent } from "../src/format.js";
 
 const repo = { owner: "owner", repo: "repo" };
 
@@ -354,14 +357,12 @@ describe("Config", () => {
 					},
 				},
 			])("%# %j", ({ data, want }) => {
-				const mockParse = jest
-					.spyOn(Link.prototype, "parse")
-					.mockImplementation(() => "parsed");
+				Link.parse.mockImplementation(() => "parsed");
 
 				c.data = data;
 
 				expect(c.parse().data).toStrictEqual(want);
-				expect(mockParse).toHaveBeenCalledTimes(data.links.length);
+				expect(Link.parse).toHaveBeenCalledTimes(data.links.length);
 			});
 		});
 	});

--- a/__tests__/file.js
+++ b/__tests__/file.js
@@ -1,9 +1,11 @@
-const currentRepo = { owner: "owner", repo: "repo" };
-jest.mock("@actions/github", () => ({ context: { repo: currentRepo } }));
+import { jest } from "@jest/globals";
 
-const { File, ParseError } = require("../src/file");
+import { github } from "../__fixtures__/@actions/github.js";
+jest.unstable_mockModule("@actions/github", () => github);
 
-const { dedent } = require("../src/format");
+const { File, ParseError } = await import("../src/file.js");
+
+import { dedent } from "../src/format.js";
 
 describe("File", () => {
 	let l = new File();
@@ -93,11 +95,11 @@ describe("File", () => {
 			it.each([
 				{
 					raw: undefined,
-					want: currentRepo,
+					want: github.context.repo,
 				},
 				{
 					raw: "",
-					want: currentRepo,
+					want: github.context.repo,
 				},
 				{
 					raw: "owner/repo",

--- a/__tests__/format.js
+++ b/__tests__/format.js
@@ -1,9 +1,9 @@
-const {
-	indent: indentFn,
+import {
+	indent as indentFn,
 	dedent,
 	commitMessage,
 	pullBody,
-} = require("../src/format");
+} from "../src/format";
 
 describe("indent", () => {
 	it.each([

--- a/__tests__/format.js
+++ b/__tests__/format.js
@@ -3,7 +3,7 @@ import {
 	dedent,
 	commitMessage,
 	pullBody,
-} from "../src/format";
+} from "../src/format.js";
 
 describe("indent", () => {
 	it.each([

--- a/__tests__/github.js
+++ b/__tests__/github.js
@@ -1,10 +1,11 @@
-const core = require("@actions/core");
-jest.mock("@actions/core");
+import { jest } from "@jest/globals";
 
-const { getOctokit } = require("@actions/github");
-jest.mock("@actions/github");
+import * as core from "../__fixtures__/@actions/core.js";
+jest.unstable_mockModule("@actions/core", () => core);
+import { github } from "../__fixtures__/@actions/github.js";
+jest.unstable_mockModule("@actions/github", () => github);
 
-const { GitHub } = require("../src/github");
+const { GitHub } = await import("../src/github.js");
 
 const repo = { owner: "owner", repo: "repo" };
 const path = "path";
@@ -38,7 +39,7 @@ describe("GitHub", () => {
 
 	describe("constructor", () => {
 		it("sets up the octokit client", () => {
-			const mockOctokit = getOctokit.mockReturnValue("ok");
+			const mockOctokit = github.getOctokit.mockReturnValue("ok");
 			expect(new GitHub("token")).toBeDefined();
 			expect(mockOctokit).toHaveBeenCalledWith("token", { log: console });
 		});

--- a/__tests__/link.js
+++ b/__tests__/link.js
@@ -1,13 +1,15 @@
-// Needed for the import of File
-const currentRepo = { owner: "owner", repo: "repo" };
-jest.mock("@actions/github", () => ({ context: { repo: currentRepo } }));
+import { jest } from "@jest/globals";
 
-const { hash } = require("crypto");
-jest.mock("crypto");
+import { github } from "../__fixtures__/@actions/github.js";
+jest.unstable_mockModule("@actions/github", () => github);
 
-const { Link, ParseError } = require("../src/link");
-const { File } = require("../src/file");
-const { dedent } = require("../src/format");
+import { crypto } from "../__fixtures__/node/crypto.js";
+jest.unstable_mockModule("node:crypto", () => crypto);
+
+const { Link, ParseError } = await import("../src/link.js");
+const { File } = await import("../src/file.js");
+
+import { dedent } from "../src/format.js";
 
 describe("Link", () => {
 	let l = new Link();
@@ -57,10 +59,10 @@ describe("Link", () => {
 				repo: { repo: "repo", owner: "owner" },
 				path: "path",
 			});
-			hash.mockReturnValue("hash");
+			crypto.hash.mockReturnValue("hash");
 
 			expect(l.SHA256).toStrictEqual("hash");
-			expect(hash).toHaveBeenCalledWith(
+			expect(crypto.hash).toHaveBeenCalledWith(
 				"sha256",
 				"owner repo path owner repo path",
 				"hex",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,4 @@ const config = {
 	restoreMocks: true,
 };
 
-module.exports = config;
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
 	"name": "action-ln",
-	"version": "0.0.0",
 	"description": "Link files between repositories",
 	"private": "true",
+	"type": "module",
+	"engines": {
+		"node": ">=18"
+	},
 	"scripts": {
 		"start": "node src/cli.js",
 		"watch:all": "find ./src/ ./test/ -type f | entr npm run all",
 		"watch:test": "find ./src/ ./test/ -type f | entr npm test",
 		"all": "npm run format && npm run lint && npm run test",
-		"test": "jest",
+		"__comments for test": "take from https://github.com/actions/javascript-action/blob/1d80419c548552e60ac84dfda8d04911c7e79025/package.json#L27C56-L27C74",
+		"test": "NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 npx jest",
 		"build": "ncc build src/index.js --source-map --minify --out dist/ --license LICENSE",
 		"build:add": "git add --force './dist/*' && git commit -m 'TODROP: dist generate'",
 		"build:clean": "rm -rf ./dist && git commit -m 'TODROP: dist cleanup' -- 'dist/*'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"start": "node src/cli.js",
+		"start": "GITHUB_REPOSITORY=nobe4/action-ln node src/cli.js",
 		"watch:all": "find ./src/ ./test/ -type f | entr npm run all",
 		"watch:test": "find ./src/ ./test/ -type f | entr npm test",
 		"all": "npm run format && npm run lint && npm run test",

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ import { parseArgs } from "node:util";
 // fix its value.
 process.env.GITHUB_REPOSITORY = "nobe4/action-ln";
 
-import { main } from "./main";
+import { main } from "./main.js";
 
 try {
 	// TODO: write some simple help if --help is passed

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,11 @@ import { parseArgs } from "node:util";
 // TODO: find a way to set the context only once, and mock it from locally.
 // Should be able to move it to its own file, in a global var, and from here
 // fix its value.
-process.env.GITHUB_REPOSITORY = "nobe4/action-ln";
+// FIXME: this doesn't anymore with ESM, since imports are hoisted to the top of
+// the file.
+// cc https://stackoverflow.com/a/51730422
+// Instead, it's setup in package.json, and the value is read from there.
+// process.env.GITHUB_REPOSITORY = "nobe4/action-ln";
 
 import { main } from "./main.js";
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,8 +7,8 @@ will be mocked.
 The configuration is loaded from a local file.
 */
 
-const core = require("@actions/core");
-const { parseArgs } = require("node:util");
+import * as core from "@actions/core";
+import { parseArgs } from "node:util";
 
 // Required by @action/github, imported by ./main
 // TODO: find a way to set the context only once, and mock it from locally.
@@ -16,7 +16,7 @@ const { parseArgs } = require("node:util");
 // fix its value.
 process.env.GITHUB_REPOSITORY = "nobe4/action-ln";
 
-const { main } = require("./main");
+import { main } from "./main";
 
 try {
 	// TODO: write some simple help if --help is passed

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
-const core = require("@actions/core");
-const fs = require("node:fs/promises");
-const yaml = require("js-yaml");
-const { indent } = require("./format");
-const { Link } = require("./link");
+import * as core from "@actions/core";
+import * as fs from "node:fs/promises";
+import * as yaml from "js-yaml";
+import { indent } from "./format.js";
+import { Link } from "./link.js";
 
 class ParseError extends Error {
 	constructor(message) {
@@ -139,4 +139,4 @@ class Config {
 	}
 }
 
-module.exports = { Config, ParseError };
+export { Config, ParseError };

--- a/src/file.js
+++ b/src/file.js
@@ -1,4 +1,5 @@
-const currentRepo = require("@actions/github").context.repo;
+import * as github from "@actions/github";
+const currentRepo = github.context.repo;
 
 class ParseError extends Error {
 	constructor(message) {
@@ -79,4 +80,4 @@ class File {
 	}
 }
 
-module.exports = { File, ParseError };
+export { File, ParseError };

--- a/src/format.js
+++ b/src/format.js
@@ -75,7 +75,7 @@ function pullBody(group, config, context) {
 	`);
 }
 
-module.exports = {
+export {
 	indent,
 	dedent,
 	prettify,

--- a/src/github.js
+++ b/src/github.js
@@ -1,6 +1,6 @@
-const core = require("@actions/core");
-const { getOctokit } = require("@actions/github");
-const { prettify: _ } = require("./format");
+import * as core from "@actions/core";
+import { getOctokit } from "@actions/github";
+import { prettify as _ } from "./format";
 
 class GitHub {
 	constructor(token) {
@@ -191,4 +191,4 @@ class GitHub {
 	}
 }
 
-module.exports = { GitHub };
+export { GitHub };

--- a/src/github.js
+++ b/src/github.js
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
 import { getOctokit } from "@actions/github";
-import { prettify as _ } from "./format";
+import { prettify as _ } from "./format.js";
 
 class GitHub {
 	constructor(token) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@
  Entrypoint to run action-ln from GitHub Actions.
 */
 
-const core = require("@actions/core");
-const context = require("@actions/github").context;
-const { main } = require("./main");
+import * as core from "@actions/core";
+import { context } from "@actions/github";
+import { main } from "./main";
 
 try {
 	const configPath = core.getInput("config-path", { required: true });

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@
 
 import * as core from "@actions/core";
 import { context } from "@actions/github";
-import { main } from "./main";
+
+import { main } from "./main.js";
 
 try {
 	const configPath = core.getInput("config-path", { required: true });

--- a/src/link.js
+++ b/src/link.js
@@ -1,7 +1,7 @@
-const { hash } = require("crypto");
+import { hash } from "node:crypto";
 
-const { indent } = require("./format");
-const { File } = require("./file");
+import { indent } from "./format.js";
+import { File } from "./file.js";
 
 class ParseError extends Error {
 	constructor(message) {
@@ -81,4 +81,4 @@ class Link {
 	}
 }
 
-module.exports = { Link, ParseError };
+export { Link, ParseError };

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,16 @@
-const core = require("@actions/core");
-const context = require("@actions/github").context;
+import * as core from "@actions/core";
+import { context } from "@actions/github";
 
-const { Config } = require("./config");
-const { GitHub } = require("./github");
-const {
+import { Config } from "./config";
+import { GitHub } from "./github";
+
+import {
 	branchName,
 	commitMessage,
 	pullBody,
 	pullTitle,
-	prettify: p,
-} = require("./format");
+	prettify as p,
+} from "./format";
 
 async function main({ configConfig, token, noop }) {
 	const gh = new GitHub(token);
@@ -110,4 +111,4 @@ async function checkIfLinkNeedsUpdate(link, gh, toRepo, headBranch) {
 	});
 }
 
-module.exports = { main };
+export default { main };

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
 import * as core from "@actions/core";
 import { context } from "@actions/github";
 
-import { Config } from "./config";
-import { GitHub } from "./github";
+import { Config } from "./config.js";
+import { GitHub } from "./github.js";
 
 import {
 	branchName,
@@ -10,7 +10,7 @@ import {
 	pullBody,
 	pullTitle,
 	prettify as p,
-} from "./format";
+} from "./format.js";
 
 async function main({ configConfig, token, noop }) {
 	const gh = new GitHub(token);
@@ -111,4 +111,4 @@ async function checkIfLinkNeedsUpdate(link, gh, toRepo, headBranch) {
 	});
 }
 
-export default { main };
+export { main };


### PR DESCRIPTION
This is required to work with some octokit packages, and seem to be a best practice as well.