### PR TITLE
fix(release): re-enable immutable release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,21 +38,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # - uses: actions/publish-immutable-action@0.0.3
-      #
-      # - run: |
-      #     # This is an ugly hack until the publish-immutable-action is fully
-      #     # ready for public usage.
-      #     # It pushes the generated code on a branch of the name of the tag
-      #     # (which is allowed, surprisingly). So when the action resolutino
-      #     # runs, it will try _either_ release or branch, both of which will
-      #     # have the 'dist' folder and will be able to run the code.
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      #
-      #     git checkout -b ${{ github.ref_name }}
-      #
-      #     git add --force './dist/*'
-      #     git commit -m "chore(release): automatically publish on edge"
-      #     git push --force origin <TAG>
-      #     git push origin ${{ github.ref_name }}
+      - uses: actions/publish-immutable-action@0.0.3


### PR DESCRIPTION
Turns out that since the `dist` folder is present, we can just use it and continue publishing packages this way.

cc #70