### PR TITLE
fix(dependabot): use proper group names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     groups:
-      all:
+      npm:
         patterns: ["*"]
     schedule:
       interval: monthly
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
-      all:
+      github-actions:
         patterns: ["*"]
     schedule:
       interval: monthly


### PR DESCRIPTION
I hoped that they would all be bundled in a single PR, but since it's not the case, I might as well use a proper name for those.