### PR TITLE
refactor(test): make all tests a bit more consistent

### DIFF
--- a/internal/github/branch_test.go
+++ b/internal/github/branch_test.go
@@ -1,9 +1,7 @@
 package github
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,13 +19,7 @@ func TestGetBranch(t *testing.T) {
 	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != branchAPIPath {
-			t.Fatal("invalid path", r.URL.Path)
-		}
-
-		if r.Method != http.MethodGet {
-			t.Fatal("invalid method", r.Method)
-		}
+		assertReq(t, r, http.MethodGet, branchAPIPath, nil)
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `{"name": "branch", "commit": { "sha": "sha123" } }`)
@@ -73,22 +65,11 @@ func TestCreateBranch(t *testing.T) {
 		t.Parallel()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/repos/owner/repo/git/refs" {
-				t.Fatal("invalid path", r.URL.Path)
-			}
-
-			if r.Method != http.MethodPost {
-				t.Fatal("invalid method", r.Method)
-			}
-
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal("failed to read body", err)
-			}
-
-			if !bytes.Equal(body, []byte(`{"ref":"refs/heads/branch","sha":"sha123"}`)) {
-				t.Fatal("invalid body", string(body))
-			}
+			assertReq(t, r,
+				http.MethodPost,
+				"/repos/owner/repo/git/refs",
+				[]byte(`{"ref":"refs/heads/branch","sha":"sha123"}`),
+			)
 
 			w.WriteHeader(http.StatusCreated)
 		}))
@@ -115,14 +96,7 @@ func TestGetOrCreateBranch(t *testing.T) {
 		t.Parallel()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/repos/owner/repo/branches/branch" {
-				t.Fatal("invalid path", r.URL.Path)
-			}
-
-			if r.Method != http.MethodGet {
-				t.Fatal("invalid method", r.Method)
-			}
-
+			assertReq(t, r, http.MethodGet, "/repos/owner/repo/branches/branch", nil)
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, `{"name": "branch", "commit": { "sha": "sha123" } }`)
 		}))
@@ -161,24 +135,10 @@ func TestGetOrCreateBranch(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch reqIndex {
 			case 0:
-				if r.URL.Path != "/repos/owner/repo/branches/branch" {
-					t.Fatal("invalid path", r.URL.Path)
-				}
-
-				if r.Method != http.MethodGet {
-					t.Fatal("invalid method", r.Method)
-				}
-
+				assertReq(t, r, http.MethodGet, "/repos/owner/repo/branches/branch", nil)
 				w.WriteHeader(http.StatusNotFound)
 			case 1:
-				if r.URL.Path != "/repos/owner/repo/git/refs" {
-					t.Fatal("invalid path", r.URL.Path)
-				}
-
-				if r.Method != http.MethodPost {
-					t.Fatal("invalid method", r.Method)
-				}
-
+				assertReq(t, r, http.MethodPost, "/repos/owner/repo/git/refs", nil)
 				w.WriteHeader(http.StatusOK)
 			}
 

--- a/internal/github/file_test.go
+++ b/internal/github/file_test.go
@@ -23,10 +23,6 @@ func TestGetFile(t *testing.T) {
 		t.Parallel()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != contentPath {
-				t.Fatal("invalid path", r.URL.Path)
-			}
-
 			fmt.Fprintln(w, `{"content": "_not base64"}`)
 		}))
 
@@ -44,6 +40,10 @@ func TestGetFile(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != contentPath {
 				t.Fatal("invalid path", r.URL.Path)
+			}
+
+			if r.Method != http.MethodGet {
+				t.Fatal("invalid method", r.Method)
 			}
 
 			fmt.Fprintln(w, `{"content": "b2s="}`)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -35,10 +35,12 @@ func New(token, endpoint string) GitHub {
 	}
 }
 
+// TODO: remove.
 type User struct {
 	Login string `json:"login"`
 }
 
+// TODO: remove.
 func (g GitHub) GetUser(ctx context.Context) (User, error) {
 	u := User{}
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// TODO: remove.
 func TestGetUser(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +117,18 @@ func TestReq(t *testing.T) {
 		t.Parallel()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != PathUser {
+				t.Fatal("invalid path", r.URL.Path)
+			}
+
+			if r.Method != http.MethodGet {
+				t.Fatal("invalid method", r.Method)
+			}
+
+			if auth := r.Header.Get("Authorization"); auth != "Bearer token" {
+				t.Fatal("invalid token", auth)
+			}
+
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, `{"data":"123"}`)
 		}))

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -17,6 +17,10 @@ func TestGetDefaultBranch(t *testing.T) {
 			t.Fatal("invalid path", r.URL.Path)
 		}
 
+		if r.Method != http.MethodGet {
+			t.Fatal("invalid method", r.Method)
+		}
+
 		fmt.Fprintln(w, `{"default_branch": "main"}`)
 	}))
 

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -13,13 +13,7 @@ func TestGetDefaultBranch(t *testing.T) {
 	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/repo" {
-			t.Fatal("invalid path", r.URL.Path)
-		}
-
-		if r.Method != http.MethodGet {
-			t.Fatal("invalid method", r.Method)
-		}
+		assertReq(t, r, http.MethodGet, "/repos/owner/repo", nil)
 
 		fmt.Fprintln(w, `{"default_branch": "main"}`)
 	}))


### PR DESCRIPTION
- Only test path, method, and body in the first success test
- Remove duplicate assertions
- Test auth in the req test
- Refactor common assertions