### PR TITLE
refactor(github): improve tests

### DIFF
--- a/internal/github/branch.go
+++ b/internal/github/branch.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	ErrBranchNotFound      = errors.New("branch not found")
-	ErrBranchAlreadyExists = errors.New("branch already exists")
+	ErrNoBranch     = errors.New("branch not found")
+	ErrBranchExists = errors.New("branch already exist")
 )
 
 type Commit struct {
@@ -32,7 +32,7 @@ func (g GitHub) GetBranch(ctx context.Context, repo Repo, branch string) (Branch
 
 	if status, err := g.req(ctx, http.MethodGet, path, nil, &b); err != nil {
 		if status == http.StatusNotFound {
-			return b, ErrBranchNotFound
+			return b, ErrNoBranch
 		}
 
 		return b, fmt.Errorf("failed to get branch: %w", err)
@@ -67,7 +67,7 @@ func (g GitHub) CreateBranch(ctx context.Context, repo Repo, branch, sha string)
 
 	if status, err := g.req(ctx, http.MethodPost, path, bytes.NewReader(body), nil); err != nil {
 		if status == http.StatusUnprocessableEntity {
-			return b, ErrBranchAlreadyExists
+			return b, ErrBranchExists
 		}
 
 		return b, fmt.Errorf("failed to create branch: %w", err)
@@ -84,7 +84,7 @@ func (g GitHub) GetOrCreateBranch(ctx context.Context, repo Repo, branch, sha st
 		return b, nil
 	}
 
-	if !errors.Is(err, ErrBranchNotFound) {
+	if !errors.Is(err, ErrNoBranch) {
 		return b, err
 	}
 

--- a/internal/github/branch_test.go
+++ b/internal/github/branch_test.go
@@ -3,7 +3,6 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -11,21 +10,18 @@ const (
 	branch        = "branch"
 	sha           = "sha123"
 	branchAPIPath = "/repos/owner/repo/branches/branch"
+	refAPIPath    = "/repos/owner/repo/git/refs"
 )
 
 func TestGetBranch(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 		assertReq(t, r, http.MethodGet, branchAPIPath, nil)
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, `{"name": "branch", "commit": { "sha": "sha123" } }`)
-	}))
-
-	g := New("token", ts.URL)
+		fmt.Fprintf(w, `{"name": "%s", "commit": { "sha": "%s" } }`, branch, sha)
+	})
 
 	got, err := g.GetBranch(t.Context(), repo, branch)
 	if err != nil {
@@ -33,27 +29,23 @@ func TestGetBranch(t *testing.T) {
 	}
 
 	if got.Name != branch {
-		t.Fatalf("expected branch name to be '%s' but got %s", branch, got.Name)
+		t.Fatalf("expected branch name to be '%s' but got '%s'", branch, got.Name)
 	}
 
-	if got.Commit.SHA != "sha123" {
-		t.Fatalf("expected commit SHA to be 'sha123' but got %s", got.Commit.SHA)
+	if got.Commit.SHA != sha {
+		t.Fatalf("expected commit SHA to be '%s' but got '%s'", sha, got.Commit.SHA)
 	}
 }
 
 func TestCreateBranch(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
 	t.Run("fails to create a new branch", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotImplemented)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		_, err := g.CreateBranch(t.Context(), repo, branch, sha)
 		if err == nil {
@@ -64,17 +56,15 @@ func TestCreateBranch(t *testing.T) {
 	t.Run("succeeds", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			assertReq(t, r,
 				http.MethodPost,
-				"/repos/owner/repo/git/refs",
-				[]byte(`{"ref":"refs/heads/branch","sha":"sha123"}`),
+				refAPIPath,
+				fmt.Appendf(nil, `{"ref":"refs/heads/%s","sha":"%s"}`, branch, sha),
 			)
 
 			w.WriteHeader(http.StatusCreated)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.CreateBranch(t.Context(), repo, branch, sha)
 		if err != nil {
@@ -90,18 +80,14 @@ func TestCreateBranch(t *testing.T) {
 func TestGetOrCreateBranch(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
 	t.Run("finds existing branch", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assertReq(t, r, http.MethodGet, "/repos/owner/repo/branches/branch", nil)
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
+			assertReq(t, r, http.MethodGet, branchAPIPath, nil)
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, `{"name": "branch", "commit": { "sha": "sha123" } }`)
-		}))
-
-		g := New("token", ts.URL)
+			fmt.Fprintf(w, `{"name": "%s", "commit": { "sha": "%s" } }`, branch, sha)
+		})
 
 		got, err := g.GetOrCreateBranch(t.Context(), repo, branch, sha)
 		if err != nil {
@@ -116,11 +102,9 @@ func TestGetOrCreateBranch(t *testing.T) {
 	t.Run("fails to get existing branch", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		_, err := g.GetOrCreateBranch(t.Context(), repo, branch, sha)
 		if err == nil {
@@ -132,20 +116,18 @@ func TestGetOrCreateBranch(t *testing.T) {
 		t.Parallel()
 
 		reqIndex := 0
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			switch reqIndex {
 			case 0:
-				assertReq(t, r, http.MethodGet, "/repos/owner/repo/branches/branch", nil)
+				assertReq(t, r, http.MethodGet, branchAPIPath, nil)
 				w.WriteHeader(http.StatusNotFound)
 			case 1:
-				assertReq(t, r, http.MethodPost, "/repos/owner/repo/git/refs", nil)
+				assertReq(t, r, http.MethodPost, refAPIPath, nil)
 				w.WriteHeader(http.StatusOK)
 			}
 
 			reqIndex++
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.GetOrCreateBranch(t.Context(), repo, branch, sha)
 		if err != nil {

--- a/internal/github/file_test.go
+++ b/internal/github/file_test.go
@@ -5,29 +5,28 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
 const (
-	contentPath = "/repos/owner/repo/contents/path/to/file"
+	filePath      = "path/to/file"
+	contentPath   = "/repos/owner/repo/contents/" + filePath
+	content       = "ok"
+	base64Content = "b2s="
+	message       = "message"
 )
 
 func TestGetFile(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{"owner"}, Repo: "repo"}
-
 	t.Run("fails to decode the content", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, `{"content": "_not base64"}`)
-		}))
+		})
 
-		g := New("token", ts.URL)
-
-		_, err := g.GetFile(t.Context(), repo, "path/to/file")
+		_, err := g.GetFile(t.Context(), repo, filePath)
 		if !errors.Is(err, base64.CorruptInputError(0)) {
 			t.Fatalf("expected base64 error, got %v", err)
 		}
@@ -36,15 +35,13 @@ func TestGetFile(t *testing.T) {
 	t.Run("succeeds", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			assertReq(t, r, http.MethodGet, contentPath, nil)
 
-			fmt.Fprintln(w, `{"content": "b2s="}`)
-		}))
+			fmt.Fprintf(w, `{"content": "%s"}`, base64Content)
+		})
 
-		g := New("token", ts.URL)
-
-		c, err := g.GetFile(t.Context(), repo, "path/to/file")
+		c, err := g.GetFile(t.Context(), repo, filePath)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -58,23 +55,20 @@ func TestGetFile(t *testing.T) {
 func TestUpdateFile(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{"owner"}, Repo: "repo"}
 	content := File{
-		Content: "ok",
-		SHA:     "sha",
-		Path:    "path/to/file",
+		Content: content,
+		SHA:     sha,
+		Path:    filePath,
 	}
 
 	t.Run("fails", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}))
+		})
 
-		g := New("token", ts.URL)
-
-		_, err := g.UpdateFile(t.Context(), repo, content, "branch", "message")
+		_, err := g.UpdateFile(t.Context(), repo, content, branch, message)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -83,26 +77,26 @@ func TestUpdateFile(t *testing.T) {
 	t.Run("succeeds", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const newSha = "newSha"
+
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			assertReq(t, r,
 				http.MethodPut,
 				contentPath,
-				[]byte(`{"message":"message","content":"b2s=","sha":"sha","branch":"branch"}`),
+				fmt.Appendf(nil, `{"message":"%s","content":"%s","sha":"%s","branch":"%s"}`, message, base64Content, sha, branch),
 			)
 
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprintln(w, `{"content": {"sha":"newSha"}}`)
-		}))
+			fmt.Fprintf(w, `{"content": {"sha":"%s"}}`, newSha)
+		})
 
-		g := New("token", ts.URL)
-
-		c, err := g.UpdateFile(t.Context(), repo, content, "branch", "message")
+		c, err := g.UpdateFile(t.Context(), repo, content, branch, message)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		if c.SHA != "newSha" {
-			t.Fatalf("expected new sha to be 'newSha' but got '%s'", c.SHA)
+		if c.SHA != newSha {
+			t.Fatalf("expected new sha to be '%s' but got '%s'", newSha, c.SHA)
 		}
 
 		if c.Content != content.Content {

--- a/internal/github/pull_test.go
+++ b/internal/github/pull_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -18,15 +17,13 @@ const (
 	pullAPIQuery = "base=base&head=owner%3Ahead&per_page=1&state=open"
 )
 
-var repo = Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
 func TestGetPull(t *testing.T) {
 	t.Parallel()
 
 	t.Run("finds a pull", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			assertReq(t, r, http.MethodGet, pullAPIPath, nil)
 
 			if r.URL.RawQuery != pullAPIQuery {
@@ -35,9 +32,7 @@ func TestGetPull(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, `[{"number": %d}]\n`, number)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.GetPull(t.Context(), repo, base, head)
 		if err != nil {
@@ -52,12 +47,10 @@ func TestGetPull(t *testing.T) {
 	t.Run("finds no pull", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, `[]`)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		_, err := g.GetPull(t.Context(), repo, "base", "head")
 		if !errors.Is(err, errNoPull) {
@@ -69,16 +62,12 @@ func TestGetPull(t *testing.T) {
 func TestCreatePull(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
 	t.Run("pull exists", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusUnprocessableEntity)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		_, err := g.CreatePull(t.Context(), repo, "base", "head", "title", "body")
 		if !errors.Is(err, errPullExists) {
@@ -89,18 +78,16 @@ func TestCreatePull(t *testing.T) {
 	t.Run("create a pull", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			assertReq(t, r,
 				http.MethodPost,
 				pullAPIPath,
-				[]byte(`{"title":"title","head":"owner:head","base":"base","body":"body"}`),
+				fmt.Appendf(nil, `{"title":"%s","head":"%s:%s","base":"%s","body":"%s"}`, title, repo.Owner.Login, head, base, body),
 			)
 
 			w.WriteHeader(http.StatusCreated)
 			fmt.Fprintf(w, `{"number": %d}\n`, number)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.CreatePull(t.Context(), repo, base, head, title, body)
 		if err != nil {
@@ -119,16 +106,14 @@ func TestGetOrCreatePull(t *testing.T) {
 	t.Run("finds existing pull", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.RawQuery != pullAPIQuery {
 				t.Fatalf("expected query to be '%s' but got '%s'", pullAPIQuery, r.URL.RawQuery)
 			}
 
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, `[{"number": %d}]\n`, number)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.GetOrCreatePull(t.Context(), repo, base, head, title, body)
 		if err != nil {
@@ -143,11 +128,9 @@ func TestGetOrCreatePull(t *testing.T) {
 	t.Run("fails to get existing pull", func(t *testing.T) {
 		t.Parallel()
 
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		_, err := g.GetOrCreatePull(t.Context(), repo, base, head, title, body)
 		if err == nil {
@@ -159,7 +142,8 @@ func TestGetOrCreatePull(t *testing.T) {
 		t.Parallel()
 
 		reqIndex := 0
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 			switch reqIndex {
 			case 0:
 				assertReq(t, r, http.MethodGet, pullAPIPath, nil)
@@ -172,9 +156,7 @@ func TestGetOrCreatePull(t *testing.T) {
 			}
 
 			reqIndex++
-		}))
-
-		g := New("token", ts.URL)
+		})
 
 		got, err := g.GetOrCreatePull(t.Context(), repo, base, head, title, body)
 		if err != nil {

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -3,34 +3,28 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
 func TestGetDefaultBranch(t *testing.T) {
 	t.Parallel()
 
-	repo := Repo{Owner: User{Login: "owner"}, Repo: "repo"}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	g := setup(t, func(w http.ResponseWriter, r *http.Request) {
 		assertReq(t, r, http.MethodGet, "/repos/owner/repo", nil)
 
-		fmt.Fprintln(w, `{"default_branch": "main"}`)
-	}))
-
-	g := New("token", ts.URL)
+		fmt.Fprintf(w, `{"default_branch": "%s"}`, branch)
+	})
 
 	b, err := g.GetDefaultBranch(t.Context(), repo)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if b != "main" {
-		t.Fatalf("expected default_branch to be 'main' but got %s", b)
+	if b != branch {
+		t.Fatalf("expected default_branch to be '%s', got '%s'", branch, b)
 	}
 
-	// ensures that this doesn't modify the repo passed as an argument.
 	if repo.DefaultBranch != "" {
-		t.Fatalf("expected repo not to change got %v", repo)
+		t.Fatalf("expected repo not to change its default branch, got %v", repo)
 	}
 }


### PR DESCRIPTION
- Use a common setup function to simplify the httptest server
- Use const/var as much as possible
- Unify messages