### PR TITLE
refactor(format): extract into its own package

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-package ln
+package format
 
 import (
 	"fmt"
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	branchName   = "auto-action-ln"
-	pullTitle    = "auto(ln): update links"
+	HeadBranch   = "auto-action-ln"
+	PullTitle    = "auto(ln): update links"
 	bodyTemplate = `
 {{/* This defines a backtick character to use in the markdown. */}}
 {{- $b := "` + "`" + `" -}}
@@ -30,7 +30,19 @@ This automated PR updates the following files:
 `
 )
 
-func pullRequestBody(l config.Links, c *config.Config, e environment.Environment) (string, error) {
+type Formatter struct {
+	config      *config.Config
+	environment environment.Environment
+}
+
+func New(c *config.Config, e environment.Environment) Formatter {
+	return Formatter{
+		config:      c,
+		environment: e,
+	}
+}
+
+func (f Formatter) PullBody(l config.Links) (string, error) {
 	t, err := template.New("Pull Body").Parse(bodyTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %w", err)
@@ -43,8 +55,8 @@ func pullRequestBody(l config.Links, c *config.Config, e environment.Environment
 		Environment environment.Environment
 	}{
 		Links:       l,
-		Config:      c,
-		Environment: e,
+		Config:      f.config,
+		Environment: f.environment,
 	}
 
 	if err := t.Execute(&out, data); err != nil {

--- a/internal/ln/ln.go
+++ b/internal/ln/ln.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nobe4/action-ln/internal/config"
 	"github.com/nobe4/action-ln/internal/environment"
+	"github.com/nobe4/action-ln/internal/format"
 	"github.com/nobe4/action-ln/internal/github"
 	"github.com/nobe4/action-ln/internal/log"
 )
@@ -22,11 +23,15 @@ func Run(ctx context.Context, e environment.Environment, g *github.GitHub) error
 		return err
 	}
 
+	f := format.New(c, e)
+
 	if err := c.Populate(ctx, g); err != nil {
 		return fmt.Errorf("failed to populate config: %w", err)
 	}
 
-	if err := processGroups(ctx, g, e, c); err != nil {
+	groups := c.Links.Groups()
+
+	if err := processGroups(ctx, g, f, groups); err != nil {
 		return fmt.Errorf("failed to process the groups: %w", err)
 	}
 


### PR DESCRIPTION
Store the config and env so the formatter can be passed around more easily.