### PR TITLE
feat(link): only commit if a commit is needed

### DIFF
--- a/internal/config/link.go
+++ b/internal/config/link.go
@@ -36,13 +36,6 @@ func (l *Link) Equal(other *Link) bool {
 }
 
 func (l *Link) NeedUpdate(ctx context.Context, g github.FileGetter, head github.Branch) (bool, error) {
-	// TODO: if the content is equal, this is not needed.
-	if head.New {
-		log.Debug("Head is new", "head", head)
-
-		return true, nil
-	}
-
 	if l.From.Content == l.To.Content {
 		log.Debug("Content is the same", "from", l.From, "to", l.To)
 

--- a/internal/config/link_test.go
+++ b/internal/config/link_test.go
@@ -13,23 +13,6 @@ var errTest = errors.New("test")
 func TestLinkNeedUpdate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("head is new", func(t *testing.T) {
-		t.Parallel()
-
-		g := mock.FileGetter{Handler: func(_ *github.File) error { return errTest }}
-		head := github.Branch{New: true}
-		l := &Link{}
-
-		needUpdate, err := l.NeedUpdate(t.Context(), g, head)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		if !needUpdate {
-			t.Fatalf("expected true, got %v", needUpdate)
-		}
-	})
-
 	t.Run("content is the same on base branch", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/ln/process.go
+++ b/internal/ln/process.go
@@ -40,8 +40,9 @@ func processLinks(ctx context.Context, g *github.GitHub, f format.Formatter, l c
 	}
 
 	if !updated {
-		// TODO don't create the PR, remove the branch.
+		// TODO don't create the PR, remove the branch if it's new.
 		log.Debug("No link was updated, cleaning up...")
+		log.Debug("head branch", "new", head.New)
 	}
 
 	pullBody, err := f.PullBody(l)


### PR DESCRIPTION
Turns out that the logic was pretty much there already, it just needed to remove the new branch logic, which will come in play later.

See: https://github.com/frozen-fishsticks/action-ln-test-0/pull/87