### PR TITLE
feat(links): test and improve combine

### DIFF
--- a/internal/config/links.go
+++ b/internal/config/links.go
@@ -76,11 +76,13 @@ func combineLinks(froms, tos []github.File) Links {
 		return Links{}
 	}
 
+	useFrom := len(tos) == 0
+
 	links := Links{}
 
 	for _, from := range froms {
-		// TODO: inherit the `ref` as well?
-		if len(tos) == 0 {
+		if useFrom {
+			// TODO: inherit the `ref` as well?
 			tos = []github.File{{Path: from.Path}}
 		}
 

--- a/internal/config/links_test.go
+++ b/internal/config/links_test.go
@@ -9,6 +9,93 @@ import (
 	gmock "github.com/nobe4/action-ln/internal/github/mock"
 )
 
+func TestCombineLinks(t *testing.T) {
+	t.Parallel()
+
+	mkFile := func(n string) github.File {
+		return github.File{
+			Path: n,
+		}
+	}
+	mkLink := func(from, to string) *Link {
+		return &Link{
+			From: mkFile(from),
+			To:   mkFile(to),
+		}
+	}
+
+	tests := []struct {
+		froms []github.File
+		tos   []github.File
+		want  Links
+	}{
+		{},
+
+		{
+			froms: []github.File{},
+			tos: []github.File{
+				mkFile("0"),
+				mkFile("1"),
+			},
+			want: Links{},
+		},
+
+		{
+			froms: []github.File{
+				mkFile("0"),
+				mkFile("1"),
+			},
+			tos: []github.File{},
+			want: Links{
+				mkLink("0", "0"),
+				mkLink("1", "1"),
+			},
+		},
+
+		{
+			froms: []github.File{
+				mkFile("0"),
+				mkFile("1"),
+			},
+			tos: []github.File{
+				mkFile("2"),
+			},
+			want: Links{
+				mkLink("0", "2"),
+				mkLink("1", "2"),
+			},
+		},
+
+		{
+			froms: []github.File{
+				mkFile("0"),
+				mkFile("1"),
+			},
+			tos: []github.File{
+				mkFile("2"),
+				mkFile("3"),
+			},
+			want: Links{
+				mkLink("0", "2"),
+				mkLink("0", "3"),
+				mkLink("1", "2"),
+				mkLink("1", "3"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			got := combineLinks(test.froms, test.tos)
+			if !got.Equal(test.want) {
+				t.Fatalf("expected %+v, got %+v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The main change fixes the logic for missing `tos` so that _each_ `from` will make a default, instead of using the first one.