### PR TITLE
docs(configuration): refactor documentations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,24 +1,19 @@
 # Configuration
 
+> [!IMPORTANT]
+> See[`all-cases.yaml`](../internal/config/all-cases.yaml) for a comprehensive
+> list of supported cases in a YAML format. It is the canonical reference for
+> configuration.
+
 The configuration lives in a YAML file that follows the following schema:
 
 ```yaml
 links:
-  - from:
-      repo: nobe4/repo-1
-      path: README.md
-    to:
-      repo: nobe4/repo-2
-      path: README.md
+  - from: owner/repo:path/to/file@main
+    to: path/to/file
+
   # ... and more
 ```
-
-See [`all-cases.yaml`](../internal/config/all-cases.yaml) for a comprehensive
-list of supported cases in a YAML format.
-
-> [!IMPORTANT]
-> This document will be refactored as part of
-> https://github.com/nobe4/action-ln/issues/66.
 
 > [!NOTE]
 > A file is usually printed by the following string:
@@ -28,14 +23,9 @@ list of supported cases in a YAML format.
 
 ## Link
 
-A link is composed of two parts:
+A link is composed of two [files](#file)
 - `from` is the _source_ of the link, where the file is _read_.
 - `to` is the _destination_ of the link, where the file is _written_.
-
-Both of those are [files](#file).
-
-If `from` to is omitted, then it's equivalent to `from.path` in the current
-repo.
 
 ## File
 
@@ -44,92 +34,11 @@ A file is the logical representation of a file on GitHub.
 It is composed of 3 parts:
 
 - `repo`: the full name of a repository, with `owner` and `repo` parts.
-
-    If the `owner` part is omitted, it defaults to the current owner.
-    If the `owner` and `repo` parts are omitted, it defaults to the current
-    owner and repo.
-
-    E.g.
-
-    ```yaml
-      # => nobe4/action-ln (TBD #33)
-      # repo key not set
-
-      # => nobe4/action-ln (TBD #33)
-      repo: action-ln
-
-      # => cli/cli
-      repo: cli/cli
-
-      # => cli/go-gh (TBD #33)
-      owner: cli
-      repo: go-gh
-
-      # => nobe4/gh-not (TBD #33)
-      repo: gh-not
-
-      # etc.
-    ```
-
 - `path`: the path relative to the root of the repository
-
-    E.g.
-
-    ```yaml
-      path: README.md
-      path: path/to/file
-      # etc.
-    ```
-
 - `ref`: a valid git commit, tag, or branch (TBD #34)
-
     It defaults to the default branch of the targeted repository.
 
-    E.g.
+## Defaults
 
-    ```yaml
-    ref: main
-    ref: v0.1.2
-    ref: sha123456
-    # etc.
-    ```
-
-There are multiple ways to references a file (using `from` here, `to` works
-similarly):
-
--
-  ```yaml
-  from:
-    repo: owner/repo
-    path: path/to/file
-    ref: ref
-  ```
-
-- Verbose (TBD #33)
-  ```yaml
-  from:
-    owner: owner
-    repo: owner
-    path: path/to/file
-    ref: ref
-  ```
-
-- Short path (TBD #33)
-  ```yaml
-  from: owner/repo/ref/path/to/file
-  ```
-
-- Alternative short path (TBD #33)
-  ```yaml
-  from: owner/repo:path/to/file@ref
-  ```
-
-- Alternative short path with implicit repo and ref (TBD #33)
-  ```yaml
-  from: path/to/file
-  ```
-
-- GitHub full URL (TBD #33)
-  ```yaml
-  from: https://github.com/owner/repo/blob/ref/path/to/file
-  ```
+- `link`: a [link](#link) whose values are used if not further specified.
+- More TBD

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 > [!IMPORTANT]
-> See[`all-cases.yaml`](../internal/config/all-cases.yaml) for a comprehensive
+> See[`all-cases.yaml`](../internal/config/fixtures/all-cases.yaml) for a comprehensive
 > list of supported cases in a YAML format. It is the canonical reference for
 > configuration.
 

--- a/internal/config/fixtures/all-cases.yaml
+++ b/internal/config/fixtures/all-cases.yaml
@@ -8,6 +8,8 @@
 #
 # The default is fixed to avoid embiguity.
 # It corresponds also to the current repo.
+#
+# See ./all-cases-no-defaults.yaml for the same links without default values.
 defaults:
   link:
     from:


### PR DESCRIPTION
`all-cases.yaml` now is the canonical showcase of configuration types. Adding prose is useless and adds weight to the documentation.