### PR TITLE
feat(status): embed a link status

### DIFF
--- a/internal/config/link.go
+++ b/internal/config/link.go
@@ -27,7 +27,18 @@ var (
 type Link struct {
 	From github.File `json:"from" yaml:"from"`
 	To   github.File `json:"to"   yaml:"to"`
+
+	Status Status `json:"status" yaml:"status"`
 }
+
+type Status string
+
+const (
+	StatusFailedToCheck   Status = "failed to check for update"
+	StatusFailedToUpdate  Status = "failed to update"
+	StatusUpdateNotNeeded Status = "update not needed"
+	StatusUpdated         Status = "updated"
+)
 
 // The parsing can be done from a couple of various format, see ParseFile.
 type RawLink struct {

--- a/internal/config/links_test.go
+++ b/internal/config/links_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"testing"
 
 	fmock "github.com/nobe4/action-ln/internal/format/mock"
@@ -193,9 +192,10 @@ func TestLinksUpdate(t *testing.T) {
 			},
 		}
 
-		updated, err := l.Update(t.Context(), g, fmock.New(), head)
-		if !errors.Is(err, errTest) {
-			t.Fatalf("want error %v, got %v", errTest, err)
+		updated := l.Update(t.Context(), g, fmock.New(), head)
+
+		if s := (*l)[0].Status; s != "failed to check for update" {
+			t.Fatalf("want status 'failed to check for update', got '%s'", s)
 		}
 
 		if updated {
@@ -215,11 +215,7 @@ func TestLinksUpdate(t *testing.T) {
 			},
 		}
 
-		updated, err := l.Update(t.Context(), g, fmock.New(), head)
-		if err != nil {
-			t.Fatalf("want no error, got %v", err)
-		}
-
+		updated := l.Update(t.Context(), g, fmock.New(), head)
 		if updated {
 			t.Fatal("want to not be updated")
 		}
@@ -246,9 +242,10 @@ func TestLinksUpdate(t *testing.T) {
 			},
 		}
 
-		updated, err := l.Update(t.Context(), g, fmock.New(), head)
-		if !errors.Is(err, errTest) {
-			t.Fatalf("want error %v, got %v", errTest, err)
+		updated := l.Update(t.Context(), g, fmock.New(), head)
+
+		if s := (*l)[0].Status; s != "failed to update" {
+			t.Fatalf("want status 'failed to update', got '%s'", s)
 		}
 
 		if updated {
@@ -277,10 +274,7 @@ func TestLinksUpdate(t *testing.T) {
 			},
 		}
 
-		updated, err := l.Update(t.Context(), g, fmock.New(), head)
-		if err != nil {
-			t.Fatalf("want no error, got %v", err)
-		}
+		updated := l.Update(t.Context(), g, fmock.New(), head)
 
 		if !updated {
 			t.Fatal("want to be updated")
@@ -325,9 +319,18 @@ func TestLinksUpdate(t *testing.T) {
 			},
 		}
 
-		updated, err := l.Update(t.Context(), g, fmock.New(), head)
-		if !errors.Is(err, errTest) {
-			t.Fatalf("want error %v, got %v", errTest, err)
+		updated := l.Update(t.Context(), g, fmock.New(), head)
+
+		if s := (*l)[0].Status; s != "update not needed" {
+			t.Fatalf("want status 'update not needed', got '%s'", s)
+		}
+
+		if s := (*l)[1].Status; s != "updated" {
+			t.Fatalf("want status 'updated', got '%s'", s)
+		}
+
+		if s := (*l)[2].Status; s != "failed to update" {
+			t.Fatalf("want status 'failed to update', got '%s'", s)
 		}
 
 		// The function failed but we had a valid update.


### PR DESCRIPTION
This helps reporting the overall resolution of updating a link. Instead of stopping the execution on error, the error is logged and the link is marked as failed. And if the link isn't updated for some reason, it's also marked as such.

Fix #206
Fix #210
Fix #215