### PR TITLE
refactor(config): extract link parse into a function

### DIFF
--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -176,14 +176,21 @@ func TestFillMissing(t *testing.T) {
 
 			c := New(github.File{}, github.Repo{})
 
-			link, want := parseLink(t, c, test.link), parseLink(t, c, test.want)
+			link, err := c.ParseLinkString(test.link)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
+			want, err := c.ParseLinkString(test.want)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 			// force to only consider the From to To filling
 			c.Defaults.Link = nil
 
-			c.fillMissing(link)
+			c.fillMissing(&link)
 
-			if !link.Equal(want) {
+			if !link.Equal(&want) {
 				t.Fatalf("expected\n%v => %v\ngot\n%v => %v", test.want, want, test.link, link)
 			}
 		})

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/nobe4/action-ln/internal/github"
@@ -93,33 +92,6 @@ func TestParseDefault(t *testing.T) {
 	})
 }
 
-// Parse link from `o/r:p -> o/r:p` for simpler test cases.
-func parseLink(t *testing.T, c *Config, s string) *Link {
-	t.Helper()
-
-	if s == "" {
-		return &Link{}
-	}
-
-	p := strings.Split(s, " -> ")
-
-	if l := len(p); l != 2 {
-		t.Fatalf("expected 2 parts, got %d for %q", l, s)
-	}
-
-	from, err := c.parseString(p[0])
-	if err != nil {
-		t.Fatalf("failed to parse file %q: %v", p[0], err)
-	}
-
-	to, err := c.parseString(p[1])
-	if err != nil {
-		t.Fatalf("failed to parse file %q: %v", p[0], err)
-	}
-
-	return &Link{From: from[0], To: to[0]}
-}
-
 func TestFillMissing(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +157,7 @@ func TestFillMissing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
+
 			// force to only consider the From to To filling
 			c.Defaults.Link = nil
 
@@ -256,13 +229,26 @@ func TestFillDefaults(t *testing.T) {
 
 			c := New(github.File{}, github.Repo{})
 
-			link, want, defaults := parseLink(t, c, test.link), parseLink(t, c, test.want), parseLink(t, c, test.def)
+			link, err := c.ParseLinkString(test.link)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-			c.Defaults.Link = defaults
+			want, err := c.ParseLinkString(test.want)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-			c.fillDefaults(link)
+			defaults, err := c.ParseLinkString(test.def)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-			if !link.Equal(want) {
+			c.Defaults.Link = &defaults
+
+			c.fillDefaults(&link)
+
+			if !link.Equal(&want) {
 				t.Fatalf("expected\n%v => %v\ngot\n%v => %v", test.want, want, test.link, link)
 			}
 		})

--- a/internal/config/link_test.go
+++ b/internal/config/link_test.go
@@ -137,6 +137,64 @@ func TestLinkNeedUpdate(t *testing.T) {
 	})
 }
 
+func TestParseLinkString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		s    string
+		want Link
+		err  error
+	}{
+		{},
+
+		{
+			s: "a -> b",
+			want: Link{
+				From: github.File{Path: "a"},
+				To:   github.File{Path: "b"},
+			},
+		},
+
+		{
+			s: "o/r:p@r -> b",
+			want: Link{
+				From: github.File{
+					Repo: github.Repo{
+						Owner: github.User{Login: "o"},
+						Repo:  "r",
+					},
+					Path: "p",
+					Ref:  "r",
+				},
+				To: github.File{Path: "b"},
+			},
+		},
+
+		{
+			s:   "a -> b -> c",
+			err: errInvalidLinkFormat,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.s, func(t *testing.T) {
+			t.Parallel()
+
+			c := Config{}
+
+			got, err := c.ParseLinkString(test.s)
+
+			if !errors.Is(err, test.err) {
+				t.Fatalf("expected error %v, got %v", test.err, err)
+			}
+
+			if !test.want.Equal(&got) {
+				t.Fatalf("expected\n%+v\ngot\n%+v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestPopulate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/github/file.go
+++ b/internal/github/file.go
@@ -36,7 +36,7 @@ func (f File) String() string {
 }
 
 func (f File) Equal(o File) bool {
-	return f.Repo.Equal(o.Repo) && f.Path == o.Path && f.SHA == o.SHA && f.Commit == o.Commit
+	return f.Repo.Equal(o.Repo) && f.Path == o.Path && f.SHA == o.SHA && f.Commit == o.Commit && f.Ref == o.Ref
 }
 
 func (f File) APIPath() string {


### PR DESCRIPTION
This is definitely useful for more than just the tests, making it a part of the config feels correct.